### PR TITLE
CubicSDR-0.2.1 requires >=rtaudio-4.1 with new error class name

### DIFF
--- a/net-wireless/cubicsdr/cubicsdr-0.2.1_alpha1_p20170209.ebuild
+++ b/net-wireless/cubicsdr/cubicsdr-0.2.1_alpha1_p20170209.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="+rtlsdr"
 
-DEPEND="media-libs/rtaudio
+DEPEND=">=media-libs/rtaudio-4.1.2
 	>net-libs/liquid-dsp-1.2.0
 	>=net-wireless/soapysdr-0.4.0
 	rtlsdr? ( net-wireless/soapy-rtlsdr )


### PR DESCRIPTION
As per their commit:

Changes in the 4.1.0 release included:
RtError class renamed RtAudioError and embedded in RtAudio.h (RtError.h deleted)